### PR TITLE
gcp.kms-cryptokey: add update action

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/kms.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/kms.py
@@ -3,11 +3,12 @@
 
 import re
 
+from c7n.exceptions import PolicyValidationError
 from c7n.utils import local_session, type_schema
 from c7n_gcp.provider import resources
 from c7n_gcp.query import QueryResourceManager, TypeInfo, ChildResourceManager, ChildTypeInfo, \
     GcpLocation
-from c7n_gcp.actions import SetIamPolicy
+from c7n_gcp.actions import MethodAction, SetIamPolicy
 from c7n_gcp.filters import IamPolicyFilter
 from c7n.filters import Filter
 
@@ -132,6 +133,59 @@ class KmsCryptoKey(ChildResourceManager):
         @classmethod
         def _get_location(cls, resource):
             return resource["name"].split('/')[3]
+
+
+@KmsCryptoKey.action_registry.register('update')
+class KmsCryptoKeyUpdate(MethodAction):
+    """Update mutable properties of a gcp.kms-cryptokey resource.
+
+    GCP action is https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys/patch
+
+    :Example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: gcp-kms-cryptokey-set-rotation
+            resource: gcp.kms-cryptokey
+            actions:
+              - type: update
+                rotationPeriod: 7776000s
+                nextRotationTime: "2027-01-01T00:00:00Z"
+    """
+    schema = type_schema(
+        'update',
+        **{
+            'rotationPeriod': {'type': 'string'},
+            'nextRotationTime': {'type': 'string'},
+            'destroyScheduledDuration': {'type': 'string'},
+            'versionTemplate': {
+                'type': 'object',
+                'additionalProperties': False,
+                'properties': {
+                    'algorithm': {'type': 'string'},
+                    'protectionLevel': {'type': 'string'},
+                },
+            },
+        })
+    method_spec = {'op': 'patch'}
+    method_perm = 'update'
+
+    def validate(self):
+        super().validate()
+        if not (self.data.keys() - {'type'}):
+            raise PolicyValidationError(
+                "policy:%s action:%s requires at least one field to update" % (
+                    self.manager.ctx.policy.name, self.type))
+        return self
+
+    def get_resource_params(self, model, resource):
+        fields = {k: v for k, v in self.data.items() if k != 'type'}
+        return {
+            'name': resource['name'],
+            'body': fields,
+            'updateMask': ','.join(fields),
+        }
 
 
 @KmsCryptoKey.filter_registry.register('iam-policy')

--- a/tools/c7n_gcp/tests/data/flights/kms-cryptokey-update/get-v1-projects-cloud-custodian-locations-us-central1-keyRings-cloud-custodian-cryptoKeys-cloud-custodian_1.json
+++ b/tools/c7n_gcp/tests/data/flights/kms-cryptokey-update/get-v1-projects-cloud-custodian-locations-us-central1-keyRings-cloud-custodian-cryptoKeys-cloud-custodian_1.json
@@ -1,0 +1,36 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 23 Apr 2019 10:30:10 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "1; mode=block",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "834",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/keyRings/cloud-custodian/cryptoKeys/cloud-custodian",
+    "primary": {
+      "name": "projects/cloud-custodian/locations/us-central1/keyRings/cloud-custodian/cryptoKeys/cloud-custodian/cryptoKeyVersions/1",
+      "state": "ENABLED",
+      "createTime": "2019-04-22T14:38:20.559717266Z",
+      "protectionLevel": "SOFTWARE",
+      "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+      "generateTime": "2019-04-22T14:38:20.559717266Z"
+    },
+    "purpose": "ENCRYPT_DECRYPT",
+    "createTime": "2019-04-22T14:38:20.559717266Z",
+    "nextRotationTime": "2027-01-01T00:00:00Z",
+    "rotationPeriod": "7776000s",
+    "versionTemplate": {
+      "protectionLevel": "SOFTWARE",
+      "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/kms-cryptokey-update/get-v1-projects-cloud-custodian-locations-us-central1-keyRings-cloud-custodian-cryptoKeys_1.json
+++ b/tools/c7n_gcp/tests/data/flights/kms-cryptokey-update/get-v1-projects-cloud-custodian-locations-us-central1-keyRings-cloud-custodian-cryptoKeys_1.json
@@ -1,0 +1,40 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 23 Apr 2019 10:29:37 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "1; mode=block",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "799",
+    "-content-encoding": "gzip",
+    "content-location": "https://cloudkms.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/keyRings/cloud-custodian/cryptoKeys?alt=json"
+  },
+  "body": {
+    "cryptoKeys": [
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/keyRings/cloud-custodian/cryptoKeys/cloud-custodian",
+        "primary": {
+          "name": "projects/cloud-custodian/locations/us-central1/keyRings/cloud-custodian/cryptoKeys/cloud-custodian/cryptoKeyVersions/1",
+          "state": "ENABLED",
+          "createTime": "2019-04-22T14:38:20.559717266Z",
+          "protectionLevel": "SOFTWARE",
+          "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+          "generateTime": "2019-04-22T14:38:20.559717266Z"
+        },
+        "purpose": "ENCRYPT_DECRYPT",
+        "createTime": "2019-04-22T14:38:20.559717266Z",
+        "versionTemplate": {
+          "protectionLevel": "SOFTWARE",
+          "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+        }
+      }
+    ],
+    "totalSize": 1
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/kms-cryptokey-update/get-v1-projects-cloud-custodian-locations-us-central1-keyRings_1.json
+++ b/tools/c7n_gcp/tests/data/flights/kms-cryptokey-update/get-v1-projects-cloud-custodian-locations-us-central1-keyRings_1.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 23 Apr 2019 10:29:32 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "1; mode=block",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "203",
+    "-content-encoding": "gzip",
+    "content-location": "https://cloudkms.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/keyRings?alt=json"
+  },
+  "body": {
+    "keyRings": [
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/keyRings/cloud-custodian",
+        "createTime": "2019-04-22T14:33:47.954967760Z"
+      }
+    ],
+    "totalSize": 1
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/kms-cryptokey-update/patch-v1-projects-cloud-custodian-locations-us-central1-keyRings-cloud-custodian-cryptoKeys-cloud-custodian_1.json
+++ b/tools/c7n_gcp/tests/data/flights/kms-cryptokey-update/patch-v1-projects-cloud-custodian-locations-us-central1-keyRings-cloud-custodian-cryptoKeys-cloud-custodian_1.json
@@ -1,0 +1,36 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 23 Apr 2019 10:30:05 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "1; mode=block",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "834",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/keyRings/cloud-custodian/cryptoKeys/cloud-custodian",
+    "primary": {
+      "name": "projects/cloud-custodian/locations/us-central1/keyRings/cloud-custodian/cryptoKeys/cloud-custodian/cryptoKeyVersions/1",
+      "state": "ENABLED",
+      "createTime": "2019-04-22T14:38:20.559717266Z",
+      "protectionLevel": "SOFTWARE",
+      "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+      "generateTime": "2019-04-22T14:38:20.559717266Z"
+    },
+    "purpose": "ENCRYPT_DECRYPT",
+    "createTime": "2019-04-22T14:38:20.559717266Z",
+    "nextRotationTime": "2027-01-01T00:00:00Z",
+    "rotationPeriod": "7776000s",
+    "versionTemplate": {
+      "protectionLevel": "SOFTWARE",
+      "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/test_kms.py
+++ b/tools/c7n_gcp/tests/test_kms.py
@@ -262,6 +262,35 @@ class KmsCryptoKeyTest(BaseTest):
         test.assertEqual(result['labels']['env'], 'production')
 
 
+    def test_kms_cryptokey_update(test):
+        factory = test.replay_flight_data('kms-cryptokey-update')
+        key_name = (
+            'projects/cloud-custodian/locations/us-central1/keyRings/'
+            'cloud-custodian/cryptoKeys/cloud-custodian'
+        )
+        p = test.load_policy(
+            {
+                'name': 'kms-cryptokey-update',
+                'resource': 'gcp.kms-cryptokey',
+                'query': [{'location': 'us-central1'}],
+                'actions': [
+                    {'type': 'update',
+                     'rotationPeriod': '7776000s',
+                     'nextRotationTime': '2027-01-01T00:00:00Z'}
+                ]
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        test.assertEqual(len(resources), 1)
+        test.assertNotIn('rotationPeriod', resources[0])
+
+        client = p.resource_manager.get_client()
+        result = client.execute_query('get', {'name': key_name})
+        test.assertEqual(result['rotationPeriod'], '7776000s')
+        test.assertEqual(result['nextRotationTime'], '2027-01-01T00:00:00Z')
+
+
 class KmsCryptoKeyVersionTest(BaseTest):
     def test_kms_cryptokey_version_query(self):
         project_id = self.project_id


### PR DESCRIPTION
Closes cloud-custodian/cloud-custodian#10535

## Description

Adds an `update` action to `gcp.kms-cryptokey` supporting the GCP
[`patch`](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys/patch)
API for the mutable, non-label fields:

- `rotationPeriod`
- `nextRotationTime`
- `destroyScheduledDuration`
- `versionTemplate` (`algorithm`, `protectionLevel`)

Label updates continue to be handled by the existing `set-labels` action.

## Example

```yaml
policies:
  - name: gcp-kms-cryptokey-set-rotation
    resource: gcp.kms-cryptokey
    actions:
      - type: update
        rotationPeriod: 7776000s
        nextRotationTime: "2027-01-01T00:00:00Z"
```

## Testing

Added `test_kms_cryptokey_update` with replayed flight data covering the
`patch` call and a follow-up `get` to confirm the change.

Note: intended for upstream cloud-custodian/cloud-custodian; opening
here first since the GitHub API is currently rejecting cross-fork PR
creation for this branch.