### PR TITLE
gcp - metrics filter - honor missing-value: 0

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/filters/metrics.py
+++ b/tools/c7n_gcp/c7n_gcp/filters/metrics.py
@@ -223,7 +223,7 @@ class GCPMetricsFilter(Filter):
         resource_name = self.manager.resource_type.get_metric_resource_name(
             resource, metric_key=self.metric_key)
         metric = self.resource_metric_dict.get(resource_name)
-        if not metric and not self.missing_value:
+        if not metric and self.missing_value is None:
             return False
         if not metric:
             metric_value = self.missing_value

--- a/tools/c7n_gcp/tests/test_filters.py
+++ b/tools/c7n_gcp/tests/test_filters.py
@@ -108,6 +108,31 @@ class TestGCPMetricsFilter(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 0)
 
+    def test_no_metrics_found_missing_value_zero(self):
+        # metric-key doesn't match any label on the returned time series, so
+        # the resource has no metric and must fall back to missing-value.
+        session_factory = self.replay_flight_data("filter-metrics")
+
+        p = self.load_policy(
+            {
+                "name": "test-metrics",
+                "resource": "gcp.instance",
+                "filters": [
+                    {'type': 'metrics',
+                    'name': 'compute.googleapis.com/instance/cpu/utilization',
+                    'metric-key': 'metric.labels.nonexistent',
+                    'aligner': 'ALIGN_MEAN',
+                    'days': 14,
+                    'value': 1,
+                    'missing-value': 0,
+                    'filter': ' resource.labels.zone = "us-east4-c"',
+                    'op': 'less-than'}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
     def test_batch_resources(self):
         policy = self.load_policy({
             "name": "test_batch_resources",


### PR DESCRIPTION
Fixes #10646

## Problem

`GCPMetricsFilter.process_resource` used:

```python
if not metric and not self.missing_value:
    return False
```

`self.missing_value` is numeric and may legitimately be `0`. `not 0` is
`True`, so a policy with `missing-value: 0` caused the filter to always
short-circuit to `False` for resources with no matching metric, instead
of defaulting the metric value to `0` and proceeding with the
comparison.

## Fix

Check for `None` explicitly instead of relying on truthiness:

```python
if not metric and self.missing_value is None:
    return False
```

## Testing

Added `test_no_metrics_found_missing_value_zero`, which sets
`missing-value: 0` on a resource with no matching metric and asserts it
is still evaluated (and matched) instead of being dropped. Confirmed
this test fails against the old condition and passes with the fix.