### PR TITLE
core - ValueFilter: recalculate value_path per resource (#10521)

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -739,12 +739,13 @@ class ValueFilter(BaseValueFilter):
             if 'value_from' in self.data:
                 values = ValuesFrom(self.data['value_from'], self.manager)
                 self.v = values.get_values()
-            elif 'value_path' in self.data:
-                self.v = self.get_path_value(i)
-            else:
+            elif 'value_path' not in self.data:
                 self.v = self.data.get('value')
             self.content_initialized = True
             self.vtype = self.data.get('value_type')
+
+        if 'value_path' in self.data:
+            self.v = self.get_path_value(i)
 
         if i is None:
             return False

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -303,6 +303,24 @@ class TestValueFilter(unittest.TestCase):
         res = vf.match(resource)
         self.assertEqual(res, False)
 
+    def test_value_path_recalculated_per_resource(self):
+        # Regression test for #10521: value_path must be reevaluated
+        # per resource, not cached from the first resource matched.
+        vf = filters.factory({
+            "type": "value",
+            "key": "a",
+            "value_path": "b",
+            "op": "eq"})
+
+        matching = {"a": "x", "b": "x"}
+        non_matching = {"a": "x", "b": "y"}
+
+        # Evaluate the non-matching resource first so a cached value_path
+        # from it (or a prior stale self.v) can't accidentally satisfy
+        # the matching resource that follows.
+        self.assertEqual(vf.match(non_matching), False)
+        self.assertEqual(vf.match(matching), True)
+
 
 class TestAgeFilter(unittest.TestCase):
 


### PR DESCRIPTION
Fixes #10521

`ValueFilter.match()` cached the comparison value `self.v` after the
first resource processed, and reused it for every subsequent resource.
This is correct for a literal `value`, but `value_path` is meant to be
evaluated per-resource (like the resource's own extracted value), so
reusing the first resource's `value_path` result for all others caused
false positives/negatives — as reported against a GCP `iam-policy`
filter using `value_path`.

Fix: move `value_path` evaluation out of the one-time
`content_initialized`-gated init block in `ValueFilter.match()` into an
unconditional per-call block, while `key`/`op`/`value`/`value_from`/
`value_type` retain their original one-time caching.

Added `test_value_path_recalculated_per_resource` in
`tests/test_filters.py`, reusing a single filter instance across two
resources with different `value_path` results to catch this
regression.

Core-only change (`c7n/filters/core.py`, `tests/test_filters.py`); no
provider-specific code touched.